### PR TITLE
Fix file display on admin page

### DIFF
--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -39,7 +39,9 @@ class DocumentController extends Controller
                 
                 if ($pdfPath) {
                     $fileInfo = $this->documentConverter->getFileInfo($registration);
-                    $fileInfo['pdf_url'] = Storage::url($pdfPath);
+                    $fileInfo['pdf_url'] = url(route('admin.documents.serve', [
+                        'filename' => ltrim(str_replace('documents/', '', $pdfPath), '/')
+                    ]));
                     $fileInfo['is_converted'] = true;
                     
                     \Log::info('Converted DOC/DOCX to PDF successfully', [
@@ -155,8 +157,11 @@ class DocumentController extends Controller
         $fullPath = Storage::disk('public')->path($filePath);
         $mimeType = mime_content_type($fullPath);
         
+        // Ensure inline display for PDFs/images and allow embedding in iframes
         return response()->file($fullPath, [
             'Content-Type' => $mimeType,
+            'Content-Disposition' => 'inline',
+            'X-Frame-Options' => 'SAMEORIGIN',
             'Access-Control-Allow-Origin' => '*',
             'Access-Control-Allow-Methods' => 'GET, OPTIONS',
             'Access-Control-Allow-Headers' => 'Content-Type',

--- a/app/Services/DocumentConverterService.php
+++ b/app/Services/DocumentConverterService.php
@@ -243,7 +243,7 @@ class DocumentConverterService
         }
 
         // Tạo URL đầy đủ đến file thông qua route public
-        $filename = basename($registration->document_file);
+        $filename = ltrim(str_replace('documents/', '', $registration->document_file), '/');
         $fileUrl = url(route('admin.documents.serve', ['filename' => $filename]));
         
         // Debug: Log URL để kiểm tra
@@ -280,7 +280,7 @@ class DocumentConverterService
         }
 
         // Tạo URL đầy đủ đến file thông qua route public
-        $filename = basename($registration->document_file);
+        $filename = ltrim(str_replace('documents/', '', $registration->document_file), '/');
         $fileUrl = url(route('admin.documents.serve', ['filename' => $filename]));
         
         // Debug: Log URL để kiểm tra
@@ -319,7 +319,9 @@ class DocumentConverterService
             return [
                 'can_view' => true,
                 'view_url' => null, // Sẽ được set bởi controller
-                'download_url' => Storage::url($registration->document_file),
+                'download_url' => url(route('admin.documents.serve', [
+                    'filename' => ltrim(str_replace('documents/', '', $registration->document_file), '/')
+                ])),
                 'original_name' => $registration->document_original_name,
                 'file_size' => $registration->formatted_file_size,
                 'mime_type' => $registration->document_mime_type,
@@ -331,7 +333,9 @@ class DocumentConverterService
         if (!$viewablePath) {
             return [
                 'can_view' => false,
-                'download_url' => Storage::url($registration->document_file),
+                'download_url' => url(route('admin.documents.serve', [
+                    'filename' => ltrim(str_replace('documents/', '', $registration->document_file), '/')
+                ])),
                 'original_name' => $registration->document_original_name,
                 'file_size' => $registration->formatted_file_size,
                 'mime_type' => $registration->document_mime_type
@@ -340,8 +344,10 @@ class DocumentConverterService
 
         return [
             'can_view' => true,
-            'view_url' => Storage::url($viewablePath),
-            'download_url' => Storage::url($registration->document_file),
+            'view_url' => url(route('admin.documents.serve', ['filename' => ltrim(str_replace('documents/', '', $viewablePath), '/') ])),
+            'download_url' => url(route('admin.documents.serve', [
+                'filename' => ltrim(str_replace('documents/', '', $registration->document_file), '/')
+            ])),
             'original_name' => $registration->document_original_name,
             'file_size' => $registration->formatted_file_size,
             'mime_type' => $registration->document_mime_type,

--- a/resources/views/backend/service-registrations/index.blade.php
+++ b/resources/views/backend/service-registrations/index.blade.php
@@ -455,7 +455,7 @@
                         <i class="fas fa-eye me-1"></i>
                         Xem tài liệu
                     </a>
-                    <a href="/storage/${item.document_file}" download="${item.document_original_name}"
+                    <a href="/admin/documents/file/${item.document_file}" download="${item.document_original_name}"
                         class="inline-flex items-center px-2 py-1 text-xs font-medium rounded-full bg-green-100 text-green-800 hover:bg-green-200">
                         <i class="fas fa-download me-1"></i>
                         Tải về

--- a/routes/web.php
+++ b/routes/web.php
@@ -72,9 +72,13 @@ Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () 
     Route::get('documents/{id}/info', [DocumentController::class, 'getFileInfo'])->name('documents.info');
     Route::post('documents/{id}/convert', [DocumentController::class, 'convertToPdf'])->name('documents.convert');
     
-    // Public file access route (không cần auth)
-    Route::get('documents/file/{filename}', [DocumentController::class, 'serveFile'])->name('documents.serve');
+    // (moved below) Public file access route: make this route accessible without auth
 });
+
+// Public file access route (không cần auth)
+Route::get('admin/documents/file/{filename}', [DocumentController::class, 'serveFile'])
+    ->where('filename', '.*')
+    ->name('admin.documents.serve');
 
 // routes/web.php
 Route::get('/test-status', function () {


### PR DESCRIPTION
Fix document viewing and downloading in the admin panel by centralizing file serving through a dedicated public route.

Previously, documents (images, PDFs, and converted DOC/DOCX) failed to display in the admin view's iframe due to issues with `Storage::url()` or direct `storage` symlink access. This change introduces a public `admin/documents/file/{filename}` route that serves files with appropriate `Content-Disposition: inline` and `X-Frame-Options: SAMEORIGIN` headers, ensuring reliable embedding and download without relying on direct symlink accessibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a40e561-54c2-4785-a5c7-bc4119048153">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a40e561-54c2-4785-a5c7-bc4119048153">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

