### PR TITLE
Fix pdf loading and event listener errors

### DIFF
--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -140,7 +140,7 @@ class DocumentController extends Controller
             return response()->json([
                 'success' => true,
                 'message' => 'Convert thành công',
-                'pdf_url' => Storage::url($pdfPath)
+                'pdf_url' => route('admin.documents.serve', ['path' => ltrim($pdfPath, '/')])
             ]);
             
         } catch (\Exception $e) {

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -84,6 +84,10 @@
     const checkAll = document.getElementById('checkAllDepartments');
     const items = document.querySelectorAll('.department-item');
 
+    if (!checkAll || !items || items.length === 0) {
+      return;
+    }
+
     checkAll.addEventListener('change', function() {
       items.forEach(cb => cb.checked = checkAll.checked);
     });


### PR DESCRIPTION
Fix `addEventListener` error by adding null checks to the layout script and ensure converted PDF URLs are served via a route.

The `addEventListener` error occurred on pages where the `checkAllDepartments` or `.department-item` elements were not present. The PDF URL change addresses 404 issues by using a Laravel route for serving converted documents, which also improves access control and ensures consistent URL generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd9938ae-42a8-4365-9d02-4ba444d05397">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dd9938ae-42a8-4365-9d02-4ba444d05397">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

